### PR TITLE
Fix build errors

### DIFF
--- a/include/argagg/argagg.hpp
+++ b/include/argagg/argagg.hpp
@@ -32,6 +32,7 @@
 #define ARGAGG_ARGAGG_ARGAGG_HPP
 
 #include <algorithm>
+#include <array>
 #include <cstdlib>
 #include <cstring>
 #include <cctype>
@@ -793,7 +794,7 @@ struct parser_map {
 parser_map validate_definitions(
   const std::vector<definition>& definitions)
 {
-  parser_map map {{nullptr}, {}};
+  parser_map map {{{nullptr}}, {}};
 
   for (auto& defn : definitions) {
 
@@ -892,7 +893,7 @@ struct parser {
     for (const auto& defn : this->definitions) {
       option_results opt_results {{}};
       results.options.insert(
-        std::move(std::make_pair(defn.name, opt_results)));
+        std::make_pair(defn.name, opt_results));
     }
 
     // Don't start off ignoring flags. We only ignore flags after a -- shows up


### PR DESCRIPTION
This fixes the following build errors that show up on my machine at home:

```
In file included from /Users/myint/tmp/argagg/test/test.cpp:1:
/Users/myint/tmp/argagg/test/../include/argagg/argagg.hpp:727:38: error:
      implicit instantiation of undefined template 'std::__1::array<const
      argagg::definition *, 256>'
  std::array<const definition*, 256> short_map;
                                     ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__tuple:116:65: note:
      template is declared here
template <class _Tp, size_t _Size> struct _LIBCPP_TYPE_VIS_ONLY array;
                                                                ^
In file included from /Users/myint/tmp/argagg/test/test.cpp:1:
/Users/myint/tmp/argagg/test/../include/argagg/argagg.hpp:895:9: error: moving a
      temporary object prevents copy elision [-Werror,-Wpessimizing-move]
        std::move(std::make_pair(defn.name, opt_results)));
        ^
/Users/myint/tmp/argagg/test/../include/argagg/argagg.hpp:895:9: note: remove
      std::move call here
        std::move(std::make_pair(defn.name, opt_results)));
        ^~~~~~~~~~                                      ~
2 errors generated.
make[2]: *** [CMakeFiles/argagg_test.dir/test/test.cpp.o] Error 1
make[1]: *** [CMakeFiles/argagg_test.dir/all] Error 2
make: *** [all] Error 2
```

```
In file included from /Users/myint/tmp/argagg/test/test.cpp:1:
/Users/myint/tmp/argagg/test/../include/argagg/argagg.hpp:797:20: error: suggest braces around initialization of subobject
      [-Werror,-Wmissing-braces]
  parser_map map {{nullptr}, {}};
                   ^~~~~~~
                   {      }
```