### PR TITLE
replace static_cast<bool> w/ non-zero comparison to avoid compiler…

### DIFF
--- a/include/argagg/argagg.hpp
+++ b/include/argagg/argagg.hpp
@@ -1381,7 +1381,7 @@ namespace convert {
   template <> inline
   bool arg(const char* arg)
   {
-    return static_cast<bool>(argagg::convert::arg<int>(arg));
+    return argagg::convert::arg<int>(arg) != 0;
   }
 
 


### PR DESCRIPTION
… warnings on MSVC.

```
using static_cast<bool>(int) on MSVC results in a compiler warning.  Proposing this as a portable substitute.
```

Discussion from SO:

https://stackoverflow.com/questions/4968033/why-does-casting-an-int-to-a-bool-give-a-warning