### PR TITLE
fix issue with using operator << on argagg types as generics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,7 @@ if( ARGAGG_BUILD_TESTS )
 
   list( APPEND ARGAGG_TEST_SOURCES "test/test.cpp" )
   list( APPEND ARGAGG_TEST_SOURCES "test/test_csv.cpp" )
+  list( APPEND ARGAGG_TEST_SOURCES "test/test_issue_39.cpp" )
 
   find_path( OPENCV_INCLUDE_DIR "opencv2/opencv.hpp" )
   find_library( OPENCV_CORE_LIBRARY opencv_core )

--- a/include/argagg/argagg.hpp
+++ b/include/argagg/argagg.hpp
@@ -716,8 +716,6 @@ struct fmt_ostream : public std::ostringstream {
 std::string fmt_string(const std::string& s);
 
 
-} // namespace argagg
-
 
 /**
  * @brief
@@ -728,8 +726,6 @@ std::ostream& operator << (std::ostream& os, const argagg::parser& x);
 
 // ---- end of declarations, header-only implementations follow ----
 
-
-namespace argagg {
 
 
 template <typename T>
@@ -1685,9 +1681,6 @@ std::string fmt_string(const std::string& s)
 }
 
 
-} // namespace argagg
-
-
 inline
 std::ostream& operator << (std::ostream& os, const argagg::parser& x)
 {
@@ -1703,6 +1696,8 @@ std::ostream& operator << (std::ostream& os, const argagg::parser& x)
   }
   return os;
 }
+
+} // namespace argagg
 
 
 #endif // ARGAGG_ARGAGG_ARGAGG_HPP

--- a/include/argagg/argagg.hpp
+++ b/include/argagg/argagg.hpp
@@ -716,7 +716,6 @@ struct fmt_ostream : public std::ostringstream {
 std::string fmt_string(const std::string& s);
 
 
-
 /**
  * @brief
  * Writes the option help to the given stream.
@@ -724,8 +723,13 @@ std::string fmt_string(const std::string& s);
 std::ostream& operator << (std::ostream& os, const argagg::parser& x);
 
 
+} // namespace argagg
+
+
 // ---- end of declarations, header-only implementations follow ----
 
+
+namespace argagg {
 
 
 template <typename T>
@@ -1696,6 +1700,7 @@ std::ostream& operator << (std::ostream& os, const argagg::parser& x)
   }
   return os;
 }
+
 
 } // namespace argagg
 

--- a/test/test_issue_39.cpp
+++ b/test/test_issue_39.cpp
@@ -1,0 +1,33 @@
+#include <sstream>
+#include <string>
+
+template<typename T>
+std::string issue_39_log(T param) {
+  std::ostringstream oss;
+  oss << param;
+  return oss.str();
+}
+
+#include "../include/argagg/argagg.hpp"
+
+#include "doctest.h"
+
+
+TEST_CASE("issue 39")
+{
+  const argagg::parser parser {{
+      {"help", {"-h", "--help"}, "print help", 0},
+      {"verbose", {"-v", "--verbose"}, "be verbose", 0},
+      {"output", {"-o", "--output"}, "output filename", 1},
+    }};
+
+  const std::string help_text = issue_39_log(parser);
+  CHECK(
+    help_text ==
+    "    -h, --help\n"
+    "        print help\n"
+    "    -v, --verbose\n"
+    "        be verbose\n"
+    "    -o, --output\n"
+    "        output filename\n");
+}


### PR DESCRIPTION
Prior to this change when trying to compile the following sample code:
```
#include <iostream>

template<typename T>
void logGeneric(T param) {
    std::cout << param << std::endl;
}

#include "include/argagg/argagg.hpp"

int main() {
    argagg::parser argParser{{{"help", {"-h", "--help"}, "Shows this help message.", 0}}};
    logGeneric<argagg::parser>(argParser);
    return 0;
}
```
I get this:
```
argagg % g++ --std=c++11 main.cpp 
main.cpp:6:15: error: call to function 'operator<<' that is neither visible in the template definition nor found by argument-dependent lookup
    std::cout << param << std::endl;
              ^
main.cpp:13:5: note: in instantiation of function template specialization 'logGeneric<argagg::parser>' requested here
    logGeneric<argagg::parser>(argParser);
    ^
./include/argagg/argagg.hpp:1692:15: note: 'operator<<' should be declared prior to the call site or in namespace 'argagg'
std::ostream& operator << (std::ostream& os, const argagg::parser& x)
              ^
1 error generated.
```

This change fixes the issue.