### PR TITLE
Solve issue #40 cmake version issue for above 3.5 version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 )
+cmake_minimum_required( VERSION 3.0...3.5)
 project( argagg CXX )
 
 add_library(


### PR DESCRIPTION
This pull request resolves a compatibility issue with CMake 4.0.0. The original CMakeLists.txt specified cmake_minimum_required(VERSION 3.1), which is no longer supported in CMake 4.0+. As a result, configuration would fail with an error regarding outdated compatibility.

Fixes: #40 

🛠️ Changes Made
Updated cmake_minimum_required(VERSION 3.1...3.5) to VERSION 3.5 to meet the new minimum requirements introduced in CMake 4.0.0 and also able to run VERSION 3.1 to 3.5. So it will also run on older version.

Ensured that no other parts of the configuration were impacted by this version change.

🧪 Testing
Successfully ran make with CMake 4.0.0.

Verified that the project configures, builds, and installs correctly.

📦 Related
Let me know if you'd like to add a screenshot of the error, mention others, or reference additional issues/branches!


<img width="687" alt="open-4" src="https://github.com/user-attachments/assets/943932ea-b2b5-408f-8be6-ecdf2fe382a1" />
